### PR TITLE
SUR-3018 - Fix: SureCart WP Query Builder PHP error on WordPress Site Health Dashboard.

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -262,8 +262,6 @@ class Query {
 		//if not null does it contains . it could be column so dont parse as string
 		//If not column then use wpdb prepare
 		//if contains $prefix
-		$contain_join = preg_replace( '/^(\s?AND ?|\s?OR ?)|\s$/i', '', $param2 );
-
 		$param2 = is_array( $param2 ) ? ( '("' . implode( '","', $param2 ) . '")' ) : ( $param2 === null
 			? 'null'
 			: ( strpos( $param2, '.' ) !== false || strpos( $param2, $wpdb->prefix ) !== false ? $param2 : $wpdb->prepare( is_numeric( $param2 ) ? '%d' : '%s', $param2 ) )

--- a/src/Query.php
+++ b/src/Query.php
@@ -262,6 +262,7 @@ class Query {
 		//if not null does it contains . it could be column so dont parse as string
 		//If not column then use wpdb prepare
 		//if contains $prefix
+		$contain_join = preg_replace( '/^(\s?AND ?|\s?OR ?)|\s$/i', '', $param2 ?? '' );
 		$param2 = is_array( $param2 ) ? ( '("' . implode( '","', $param2 ) . '")' ) : ( $param2 === null
 			? 'null'
 			: ( strpos( $param2, '.' ) !== false || strpos( $param2, $wpdb->prefix ) !== false ? $param2 : $wpdb->prepare( is_numeric( $param2 ) ? '%d' : '%s', $param2 ) )


### PR DESCRIPTION
Task - [SUR-3018](https://linear.app/surecart/issue/SUR-3018/surecart-wp-query-builder-php-error-on-wordpress-site-health-dashboard)