### PR TITLE
Harden value escaping in where() and join() expressions (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Generated
 /tests/.tmp
 composer.lock
+
+# Claude Code
+.claude/

--- a/src/Query.php
+++ b/src/Query.php
@@ -257,16 +257,7 @@ class Query {
 		}
 
 
-		//first check if is array if so then make a string out of array
-		//if not array but null then set value as null
-		//if not null does it contains . it could be column so dont parse as string
-		//If not column then use wpdb prepare
-		//if contains $prefix
-		$contain_join = preg_replace( '/^(\s?AND ?|\s?OR ?)|\s$/i', '', $param2 ?? '' );
-		$param2 = is_array( $param2 ) ? ( '("' . implode( '","', $param2 ) . '")' ) : ( $param2 === null
-			? 'null'
-			: ( strpos( $param2, '.' ) !== false || strpos( $param2, $wpdb->prefix ) !== false ? $param2 : $wpdb->prepare( is_numeric( $param2 ) ? '%d' : '%s', $param2 ) )
-		);
+		$param2 = $this->prepare_value_expression( $param2 );
 
 		$this->where[] = [
 			'joint'     => $joint,
@@ -508,11 +499,7 @@ class Query {
 			$operator = '=';
 		}
 
-		$referenceKey = is_array( $referenceKey ) ? ( '(\'' . implode( '\',\'', $referenceKey ) . '\')' )
-			: ( $referenceKey === null
-				? 'null'
-				: ( strpos( $referenceKey, '.' ) !== false || strpos( $referenceKey, $wpdb->prefix ) !== false ? $referenceKey : $wpdb->prepare( is_numeric( $referenceKey ) ? '%d' : '%s', $referenceKey ) )
-			);
+		$referenceKey = $this->prepare_value_expression( $referenceKey );
 
 		$join['on'][] = [
 			'joint'     => $joint,
@@ -1388,6 +1375,43 @@ class Query {
 		}
 
 		return $callback && is_callable( $callback ) ? call_user_func_array( $callback, [ $value ] ) : $value;
+	}
+
+	/**
+	 * Escape a WHERE/JOIN value for safe inclusion in the generated SQL.
+	 *
+	 * Array  -> `IN (...)` list with each element prepared individually.
+	 * Null   -> bare `null`.
+	 * Bare `table.col` identifier reference -> raw passthrough.
+	 * Everything else -> `$wpdb->prepare()`.
+	 *
+	 * @param mixed $value Value to escape.
+	 *
+	 * @return string
+	 */
+	private function prepare_value_expression( $value ) {
+		global $wpdb;
+
+		if ( is_array( $value ) ) {
+			$prepared = array_map(
+				function ( $item ) use ( $wpdb ) {
+					return $wpdb->prepare( is_numeric( $item ) ? '%d' : '%s', $item );
+				},
+				$value
+			);
+			return '(' . implode( ',', $prepared ) . ')';
+		}
+
+		if ( null === $value ) {
+			return 'null';
+		}
+
+		// Safe bare column or table-qualified column reference.
+		if ( is_string( $value ) && preg_match( '/^[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*$/', $value ) ) {
+			return $value;
+		}
+
+		return $wpdb->prepare( is_numeric( $value ) ? '%d' : '%s', $value );
 	}
 
 	/**

--- a/src/Query.php
+++ b/src/Query.php
@@ -1406,7 +1406,9 @@ class Query {
 			return 'null';
 		}
 
-		// Safe bare column or table-qualified column reference.
+		// Safe table-qualified column reference (e.g., 'users.id', 'posts.post_title').
+		// Only allows valid SQL identifier format: table.column where both parts start
+		// with letter/underscore and contain only letters, numbers, underscores.
 		if ( is_string( $value ) && preg_match( '/^[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*$/', $value ) ) {
 			return $value;
 		}


### PR DESCRIPTION
* Harden value escaping in where() and join() expressions

Always route scalar values through $wpdb->prepare(), except for bare column or table.column identifier references matched by a strict regex. Array elements in IN (...) lists are prepared individually.

The prior heuristic skipped prepare() whenever a value contained a dot or the WP table prefix substring, which could allow caller-supplied input to reach the generated SQL unescaped.

Ref: SUR-5139

* Require table.column form for identifier passthrough

The prior regex made the dot optional, which matched any bare word value (e.g. 'testmodel', 'stripe', 'admin'). Those values were then routed through raw instead of prepared, producing invalid SQL.

Tightens the passthrough to require the full table.column form so bare string values are always prepared.

Ref: SUR-5139

* Extract prepare_value_expression() helper shared by where() and join()

Both methods had identical value-escaping ladders. Collapsing into a single private helper removes duplication and keeps the regex + format specifier rules in one place.

No behavior change from the previous two commits on this branch.

Ref: SUR-5139